### PR TITLE
Add TypeScript sources to NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/src/index.d.ts",
   "files": [
     "dist/src/**",
+    "src/**",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
Hello! Thanks very much for this package.

I've been using it in a create-react-app codebase and the build toolchain is complaining that it can't find `src/index.ts` to create a source map. I believe the fix is as simple as including the `src` directory in the built NPM package.